### PR TITLE
Create unique GC log files and set limits on the space usage

### DIFF
--- a/recipes/_defaults.rb
+++ b/recipes/_defaults.rb
@@ -5,7 +5,10 @@
 
 unless node['kafka']['gc_log_opts']
   node.default['kafka']['gc_log_opts'] = %W[
-    -Xloggc:#{::File.join(node['kafka']['log_dir'], 'kafka-gc.log')}
+    -Xloggc:#{::File.join(node['kafka']['log_dir'], 'kafka-gc-pid-$$-$(hostname)-$(date +\'%Y%m%d%H%M\').log')}
+    -XX:+UseGCLogFileRotation
+    -XX:NumberOfGCLogFiles=20
+    -XX:GCLogFileSize=20M
     -XX:+PrintGCDateStamps
     -XX:+PrintGCTimeStamps
   ].join(' ')


### PR DESCRIPTION
Changes include
- Creation of GC log files with a unique name
- Rotate log files after 20 files
- Each logfile is set to 20 M max to limit the amount of space used