### PR TITLE
Fix helper method typo

### DIFF
--- a/libraries/log4j.rb
+++ b/libraries/log4j.rb
@@ -48,7 +48,7 @@ module Kafka
       s.split('_').reduce('') { |acc, elem| acc << elem.capitalize }
     end
 
-    def newlinew
+    def newline
       @newline ||= "\n".freeze
     end
   end


### PR DESCRIPTION
# Description

Fix `newline` helper typo. This first appeared in Sous-ify PR.

## Check List

- [ ] All tests pass. See TESTING.md for details
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
