### PR TITLE
Fix missing newlines in env file and log4j.properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix missing newlines in env file and log4j.properties
+- Fix serverspec tests
+- Fix dokken verifier path
 - resolved cookstyle error: test/integration/default/serverspec/default_spec.rb:1:1 convention: `Style/Encoding`
 - resolved cookstyle error: test/integration/helpers/serverspec/Gemfile:1:1 convention: `Style/Encoding`
 - resolved cookstyle error: test/integration/helpers/serverspec/spec_helper.rb:1:1 convention: `Style/Encoding`

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,6 +13,10 @@ provisioner:
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   install_strategy: once
 
+verifier:
+  root_path: '/opt/verifier'
+  sudo: false
+
 platforms:
   - name: centos-7
     driver:

--- a/libraries/env.rb
+++ b/libraries/env.rb
@@ -3,6 +3,8 @@
 # Libraries:: env
 #
 
+require 'English'
+
 module Kafka
   class Env
     def initialize(attributes)

--- a/libraries/log4j.rb
+++ b/libraries/log4j.rb
@@ -3,6 +3,8 @@
 # Libraries:: log4j
 #
 
+require 'English'
+
 module Kafka
   module Log4J
     def render_appender(name, options)

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -57,6 +57,10 @@ describe 'kafka::default' do
         '/opt/kafka/config/log4j.properties'
       end
     end
+    describe file('/opt/kafka/config/log4j.properties') do
+      let(:path) { '/sbin:/usr/local/sbin:$PATH' }
+      its('content') { should match %r{log4j.appender.kafkaAppender.File=/var/log/kafka/kafka.log\nlog4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout} }
+    end
   end
 
   describe '/opt/kafka/config/server.properties' do

--- a/test/integration/helpers/serverspec/support/platform_helpers.rb
+++ b/test/integration/helpers/serverspec/support/platform_helpers.rb
@@ -19,6 +19,10 @@ module PlatformHelpers
     family == 'fedora' || family == 'redhat7'
   end
 
+  def run_command(cmd)
+    Specinfra.backend.run_command(cmd)
+  end
+
   private
 
   def family

--- a/test/integration/helpers/serverspec/support/service_common.rb
+++ b/test/integration/helpers/serverspec/support/service_common.rb
@@ -20,7 +20,7 @@ shared_context 'service setup' do
   end
 
   let :status_command do
-    shell_out! status_command_string
+    run_command status_command_string
   end
 
   let :start_regexp do
@@ -47,7 +47,7 @@ shared_context 'service setup' do
   end
 
   after :all do
-    shell_out! %(ps ax | grep -i 'zookeeper' | grep -v grep | awk '{print $1}' | xargs kill -SIGKILL)
+    run_command %(ps ax | grep -i 'zookeeper' | grep -v grep | awk '{print $1}' | xargs kill -SIGKILL)
     Process.wait(@pid)
   end
 
@@ -59,7 +59,7 @@ shared_context 'service setup' do
   end
 
   def start_kafka(wait = false)
-    result = shell_out!(start_command_string)
+    result = run_command(start_command_string)
     if wait && result.exit_status == 0
       await do
         File.exist?(log_file_path) && File.read(log_file_path).match(start_regexp)
@@ -69,7 +69,7 @@ shared_context 'service setup' do
   end
 
   def stop_kafka(wait = false)
-    result = shell_out!(stop_command_string)
+    result = run_command(stop_command_string)
     if wait && result.exit_status == 0
       await { File.exist?(log_file_path) && File.read(log_file_path).match(stop_regexp) }
     end

--- a/test/integration/systemd/serverspec/required_files_spec.rb
+++ b/test/integration/systemd/serverspec/required_files_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'required files for systemd init style' do
   describe 'environment file' do
     let :env_file do
-      file(debian? ? '/etc/default/kafka' : '/etc/sysconfig/kafka')
+      file(debian? || ubuntu? ? '/etc/default/kafka' : '/etc/sysconfig/kafka')
     end
 
     it 'exists' do

--- a/test/integration/systemd/serverspec/required_files_spec.rb
+++ b/test/integration/systemd/serverspec/required_files_spec.rb
@@ -21,6 +21,10 @@ describe 'required files for systemd init style' do
     it 'has 644 permissions' do
       expect(env_file).to be_mode 644
     end
+
+    it 'is properly formatted with newlines' do
+      expect(env_file.content).to match(%r{SCALA_VERSION=.*\nKAFKA_OPTS=.*\nJMX_PORT=.*})
+    end
   end
 
   describe 'init configuration' do

--- a/test/integration/systemd/serverspec/service_spec.rb
+++ b/test/integration/systemd/serverspec/service_spec.rb
@@ -20,7 +20,7 @@ describe 'service for systemd init style' do
   end
 
   before do
-    shell_out! 'systemctl reset-failed kafka.service'
+    run_command 'systemctl reset-failed kafka.service'
   end
 
   describe service('kafka'), pending: centos? && systemd? do
@@ -47,20 +47,20 @@ describe 'service for systemd init style' do
       end
 
       it 'sets configured `ulimit` values' do
-        pid = shell_out!(pid_command_string).stdout.strip
+        pid = run_command(pid_command_string).stdout.strip
         limits = file("/proc/#{pid}/limits").content
         expect(limits).to match(/Max open files\s+128000\s+128000\s+files/i)
       end
 
       it 'runs as the configured user' do
-        pid = shell_out!(pid_command_string).stdout.strip
-        user = shell_out!(format('ps -p %s -o user --no-header', pid)).stdout.strip
+        pid = run_command(pid_command_string).stdout.strip
+        user = run_command(format('ps -p %s -o user --no-header', pid)).stdout.strip
         expect(user).to eq('kafka')
       end
 
       it 'runs as the configured group' do
-        pid = shell_out!(pid_command_string).stdout.strip
-        group = shell_out!(format('ps -p %s -o group --no-header', pid)).stdout.strip
+        pid = run_command(pid_command_string).stdout.strip
+        group = run_command(format('ps -p %s -o group --no-header', pid)).stdout.strip
         expect(group).to eq('kafka')
       end
 
@@ -86,9 +86,9 @@ describe 'service for systemd init style' do
       end
 
       it 'does not start a new process' do
-        first_pid = shell_out!(pid_command_string).stdout.strip
+        first_pid = run_command(pid_command_string).stdout.strip
         start_kafka
-        new_pid = shell_out!(pid_command_string).stdout.strip
+        new_pid = run_command(pid_command_string).stdout.strip
         expect(first_pid).to eq(new_pid)
       end
     end


### PR DESCRIPTION
# Description

This PR fixes the missing newline issue described in #189 

The change in [this commit](https://github.com/sous-chefs/kafka/commit/50e9084c8604d51e0e6a9b63439cfa1abcf9186b) broke the newlines by replacing occurrences of `$/` with `$INPUT_RECORD_SEPARATOR` without adding a `require 'English'` that defines this variable.

I have added tests to verify some of the content of both the env file and the log4j.properties file.

While fixing this issue i also found out that the serverspec test suite was actually not being executed due to an invalid verifier path when using kitchen-dokken. kitchen-dokken expects the tests to be in `/opt/verifier` but the default path is `/tmp/verifier`, causing no tests to be executed.

When the tests were working again, i found out that the test suite was actually broken. The following changes were made to restore test functionality:

* revert some changes made in [this commit](https://github.com/sous-chefs/kafka/commit/1eeaa6578dd488bd0e462982d9dde6710a5244e3) since `shell_out!` doesn't work in serverspec.
* Fixed the env file location for Ubuntu

The best thing would probably be to convert all tests to inspec, but I'll leave that for another PR :)

## Issues Resolved

#189 
#190 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
